### PR TITLE
New HT structural model

### DIFF
--- a/D8.py
+++ b/D8.py
@@ -373,8 +373,8 @@ class Aircraft(Model):
                     self.HT['L_{shear}'] >= self.HT['L_{h_{rect_{out}}}'] + self.HT['L_{h_{tri_{out}}}'],
 
                     # Constraints for stability: TODO find another way
-                    self.HT['M_r']*self.HT['c_{root_{ht}}'] >= 0.1 * self.HT['M_{r_{out}}']*self.HT['c_{attach}'],
-                    self.HT['b_{ht_{out}}'] >= 1./6.*self.HT['b_{ht}'],
+                    self.HT['M_r']*self.HT['c_{root_{ht}}'] >= 0.25 * self.HT['M_{r_{out}}']*self.HT['c_{attach}'],
+                    # self.HT['b_{ht_{out}}'] >= 1./6.*self.HT['b_{ht}'],
 
                     # HT/VT joint constraint
                     self.HT['b_{ht}'] / (2. * self.fuse['w_{fuse}']) * self.HT['\lambda_{ht}'] * self.HT['c_{root_{ht}}'] ==

--- a/D8.py
+++ b/D8.py
@@ -354,8 +354,8 @@ class Aircraft(Model):
             with SignomialsEnabled():
                 constraints.extend([
                     # Pin VT joint moment constraint #TODO may be problematic, should check
-                    SignomialEquality(self.HT['L_{h_{rect}}'] * (self.HT['b_{ht}'] / 2. - self.fuse['w_{fuse}']),
-                                      self.HT['L_{h_{tri}}'] * (self.fuse['w_{fuse}'] - self.HT['b_{ht}'] / 3.)), # [SP] #[SPEquality]
+                    # SignomialEquality(self.HT['L_{h_{rect}}'] * (self.HT['b_{ht}'] / 2. - self.fuse['w_{fuse}']),
+                    #                   self.HT['L_{h_{tri}}'] * (self.fuse['w_{fuse}'] - self.HT['b_{ht}'] / 3.)), # [SP] #[SPEquality]
 
                     # HT outboard half-span
                     self.HT['b_{ht_{out}}'] >= 0.5*self.HT['b_{ht}'] - self.fuse['w_{fuse}'], # [SP]
@@ -373,8 +373,8 @@ class Aircraft(Model):
                     self.HT['L_{shear}'] >= self.HT['L_{h_{rect_{out}}}'] + self.HT['L_{h_{tri_{out}}}'],
 
                     # Constraints for stability: TODO find another way
-                    self.HT['M_r']*self.HT['c_{root_{ht}}'] >= 0.25 * self.HT['M_{r_{out}}']*self.HT['c_{attach}'],
-                    # self.HT['b_{ht_{out}}'] >= 1./6.*self.HT['b_{ht}'],
+                    self.HT['AR_{ht}'] >= 6.,
+                    # self.HT['M_r']*self.HT['c_{root_{ht}}'] >= 0.25 * self.HT['M_{r_{out}}']*self.HT['c_{attach}'],
 
                     # HT/VT joint constraint
                     self.HT['b_{ht}'] / (2. * self.fuse['w_{fuse}']) * self.HT['\lambda_{ht}'] * self.HT['c_{root_{ht}}'] ==

--- a/D8.py
+++ b/D8.py
@@ -358,10 +358,10 @@ class Aircraft(Model):
                     #                   self.HT['L_{h_{tri}}'] * (self.fuse['w_{fuse}'] - self.HT['b_{ht}'] / 3.)), # [SP] #[SPEquality]
                     # Pin VT constraint (wingtip moment = 0Nm) #TODO: may be problematic as well, relax if doesn't solve
                     SignomialEquality(self.HT['b_{ht}']/4.*self.HT['L_{h_{rect}}'] + self.HT['b_{ht}']/3.*self.HT['L_{h_{tri}}'],
-                                      self.HT['b_{ht_{out}}'] * self.HT['L_{h_{max}}']/2.),
+                                      self.HT['b_{ht_{out}}'] * self.HT['L_{h_{max}}']/2.), #[SP] #[SPEquality]
 
                     # HT outboard half-span
-                    self.HT['b_{ht_{out}}'] >= 0.5*self.HT['b_{ht}'] - self.fuse['w_{fuse}'], # [SP]
+                    SignomialEquality(self.HT['b_{ht_{out}}'] , 0.5*self.HT['b_{ht}'] - self.fuse['w_{fuse}']), #[SP] #[SPEquality]
 
                     # HT center moment
                     self.HT['M_r'] * self.HT['c_{root_{ht}}'] >= self.HT['L_{h_{rect}}'] * (
@@ -374,10 +374,6 @@ class Aircraft(Model):
 
                     # HT joint shear (max shear)
                     self.HT['L_{shear}'] >= self.HT['L_{h_{rect_{out}}}'] + self.HT['L_{h_{tri_{out}}}'],
-
-                    # Constraints for stability: TODO find another way
-                    self.HT['AR_{ht}'] >= 6.,
-                    # self.HT['M_r']*self.HT['c_{root_{ht}}'] >= 0.25 * self.HT['M_{r_{out}}']*self.HT['c_{attach}'],
 
                     # HT/VT joint constraint
                     self.HT['b_{ht}'] / (2. * self.fuse['w_{fuse}']) * self.HT['\lambda_{ht}'] * self.HT['c_{root_{ht}}'] ==

--- a/D8.py
+++ b/D8.py
@@ -353,9 +353,12 @@ class Aircraft(Model):
         if piHT:
             with SignomialsEnabled():
                 constraints.extend([
-                    # Pin VT joint moment constraint #TODO may be problematic, should check
+                    # Pin VT joint moment constraint #PROBLEMATIC, instead using wingtip moment
                     # SignomialEquality(self.HT['L_{h_{rect}}'] * (self.HT['b_{ht}'] / 2. - self.fuse['w_{fuse}']),
                     #                   self.HT['L_{h_{tri}}'] * (self.fuse['w_{fuse}'] - self.HT['b_{ht}'] / 3.)), # [SP] #[SPEquality]
+                    # Pin VT constraint (wingtip moment = 0Nm) #TODO: may be problematic as well, relax if doesn't solve
+                    SignomialEquality(self.HT['b_{ht}']/4.*self.HT['L_{h_{rect}}'] + self.HT['b_{ht}']/3.*self.HT['L_{h_{tri}}'],
+                                      self.HT['b_{ht_{out}}'] * self.HT['L_{h_{max}}']/2.),
 
                     # HT outboard half-span
                     self.HT['b_{ht_{out}}'] >= 0.5*self.HT['b_{ht}'] - self.fuse['w_{fuse}'], # [SP]


### PR DESCRIPTION
@mayork this gets our horizontal tails within 20% of TASOPT for D8.2, and runs without any arbitrary constraints. Had to add two SigEqs to make it work, but they don't generate much slowdown in runtime. The HT is still underweight, but much less so. Will investigate after merge. 